### PR TITLE
losen aerospike client dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/aerospike-p.svg)](http://badge.fury.io/js/aerospike-p)
 
-**aerospike-p** is a promisified Aerospike Node.js client library. It internally uses the official [aerospike](https://github.com/aerospike/aerospike-client-nodejs) (**1.0.47**) client driver.
+**aerospike-p** is a promisified Aerospike Node.js client library. It internally uses the official [aerospike](https://github.com/aerospike/aerospike-client-nodejs) (**~1.0.50**) client driver.
 
 ```javascript
 var aerospike = require('aerospike-p');

--- a/lib/utils/promisify.js
+++ b/lib/utils/promisify.js
@@ -12,7 +12,7 @@ exports = module.exports = function(srcObj, methods, destObj) {
 
     _.each(methods, function(m) {
         var fn = srcObj[m];
-        console.assert(fn && _.isFunction(fn) && (fn.length > 0), 'Invalid function: ' + m);
+        console.assert(fn && _.isFunction(fn), 'Invalid function: ' + m);
 
         destObj[m] = function() {
             // change undefined args to "null"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "main": "lib/index.js",
     "dependencies": {
-        "aerospike": "1.0.47",
+        "aerospike": "~1.0.50",
         "bluebird": "2.x",
         "lodash": "3.x"
     },

--- a/test/utils/promisifyTest.js
+++ b/test/utils/promisifyTest.js
@@ -114,7 +114,6 @@ describe('utils/promisify', function() {
     describe('invalid methods', function() {
         expectError({}, ['foo'], {}); // not exists
         expectError({ foo: 'bar' }, ['foo'], {}); // not a function
-        expectError({ foo: emptyFn }, ['foo'], {}); // empty function
     });
 
     describe('empty method list', function() {


### PR DESCRIPTION
This PR losens the aerospike dependency so that the latest patches get in without having to explicitly update the `package.json` file every time aerospike releases.